### PR TITLE
Fixed the `ProgramChange` function to ensure the generated MIDI message has the correct 2-byte length.

### DIFF
--- a/event.go
+++ b/event.go
@@ -68,14 +68,13 @@ func ControlChange(channel, controller, newVal int) *Event {
 	}
 }
 
-// ProgramChange sets a new value the same way as ControlChange
-// but implements Mode control and special message by using reserved controller numbers 120-127.
-func ProgramChange(channel, controller, newVal int) *Event {
+// ProgramChange sets a new Program Number for the given channel.
+// The new program number is between 0-127.
+func ProgramChange(channel, newProgram int) *Event {
 	return &Event{
 		MsgChan:    uint8(channel),
 		MsgType:    uint8(EventByteMap["ProgramChange"]),
-		Controller: uint8(controller),
-		NewValue:   uint8(newVal),
+		NewProgram: uint8(newProgram),
 	}
 }
 
@@ -345,9 +344,6 @@ func (e *Event) Encode() ([]byte, error) {
 		*/
 	case 0xC:
 		if err := binary.Write(buff, binary.BigEndian, e.NewProgram); err != nil {
-			return buff.Bytes(), err
-		}
-		if err := binary.Write(buff, binary.BigEndian, e.NewValue); err != nil {
 			return buff.Bytes(), err
 		}
 		// Channel Pressure (Aftertouch)

--- a/event_test.go
+++ b/event_test.go
@@ -1,6 +1,7 @@
 package midi
 
 import (
+	"bytes"
 	"errors"
 	"reflect"
 	"testing"
@@ -21,5 +22,23 @@ func TestEventString(t *testing.T) {
 	str := event.String()
 	if str != expect {
 		t.Errorf("Expected '%s' got '%s'", expect, str)
+	}
+}
+
+func TestProgramChangeEncoding(t *testing.T) {
+	// Test ProgramChange event encoding conforms to MIDI protocol standards
+	// This test verifies the fix for the bug where an extra byte was being written
+	event := ProgramChange(0, 1)
+
+	// Encode the event
+	data, err := event.Encode()
+	if err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+
+	// Verify encoding result follows MIDI standard
+	expected := []byte{0x00, 0xC0, 0x01}
+	if !bytes.Equal(data, expected) {
+		t.Errorf("ProgramChange encoding mismatch. Expected %v, got %v", expected, data)
 	}
 }


### PR DESCRIPTION
Background
This PR addresses a good first issue (#5 ) related to the ProgramChange message length not conforming to the MIDI standard.

Changes
Fixed the ProgramChange function to ensure the generated MIDI message has the correct 2-byte length.
Updated unit tests to validate the proper message format.
Testing
All local test cases have passed successfully.
Verified with a sample MIDI file that instrument switching works as expected.
Related Issue
Resolves #5 